### PR TITLE
Accepts options for `dajarize` as hash

### DIFF
--- a/lib/pebbles/dajare.rb
+++ b/lib/pebbles/dajare.rb
@@ -4,13 +4,13 @@ require 'pebbles/dajare/version'
 module Pebbles
   module Dajare
 
-    def generate_dajare(phrase, degree=2)
+    def generate_dajare(phrase, degree: 2, region: 'jp')
       components = phrase.scan(/./)
 
       prefix = components[0..-(degree+1)].join
       src_dajare = components[-degree..-1].join
 
-      results = GoogleSuggest.suggest_for(src_dajare)
+      results = GoogleSuggest.suggest_for(src_dajare, region: region)
 
       dajares = results.map do |result|
         prefix + result.split(' ').shift
@@ -18,8 +18,8 @@ module Pebbles
       return dajares
     end
 
-    def dajarize(degree=2)
-      Pebbles::Dajare.generate_dajare(self.to_s, degree)
+    def dajarize(degree: 2, region: 'jp')
+      Pebbles::Dajare.generate_dajare(self.to_s, degree: degree, region: region)
     end
 
     module_function :generate_dajare

--- a/spec/pebbles/dajare_spec.rb
+++ b/spec/pebbles/dajare_spec.rb
@@ -1,9 +1,11 @@
-# encoding: utf-8
 require 'pebbles/dajare'
 
 describe Pebbles::Dajare do
+  let(:options) { { region: 'jp' } }
+  let(:keyword) { 'ます' }
+
   before do
-    GoogleSuggest.stub(:suggest_for).with('ます').and_return([
+    GoogleSuggest.stub(:suggest_for).with(keyword, options).and_return([
       '舛添要一'
     ])
   end

--- a/spec/pebbles/dajare_spec.rb
+++ b/spec/pebbles/dajare_spec.rb
@@ -8,13 +8,13 @@ describe Pebbles::Dajare do
     ])
   end
 
-  context ".generate_dajare" do
+  describe ".generate_dajare" do
     subject { Pebbles::Dajare.generate_dajare 'ありがとうございます' }
 
     its(:shift) { should == 'ありがとうござい舛添要一' }
   end
 
-  context "String#dajarize" do
+  describe "String#dajarize" do
     subject { 'ありがとうございます'.dajarize }
 
     its(:shift) { should == 'ありがとうござい舛添要一' }

--- a/spec/pebbles/dajare_spec.rb
+++ b/spec/pebbles/dajare_spec.rb
@@ -14,6 +14,14 @@ describe Pebbles::Dajare do
     subject { Pebbles::Dajare.generate_dajare 'ありがとうございます' }
 
     its(:shift) { should == 'ありがとうござい舛添要一' }
+
+    context 'Giving degree option' do
+      let(:keyword) { 'います' }
+
+      subject { Pebbles::Dajare.generate_dajare('ありがとうございます', degree: 3) }
+
+      its(:shift) { should == 'ありがとうござ舛添要一' }
+    end
   end
 
   describe "String#dajarize" do

--- a/spec/pebbles/dajare_spec.rb
+++ b/spec/pebbles/dajare_spec.rb
@@ -22,6 +22,13 @@ describe Pebbles::Dajare do
 
       its(:shift) { should == 'ありがとうござ舛添要一' }
     end
+    context 'Giving region option' do
+      let(:options) { { region: 'us' } }
+
+      subject { Pebbles::Dajare.generate_dajare('ありがとうございます', region: 'us') }
+
+      its(:shift) { should == 'ありがとうござい舛添要一' }
+    end
   end
 
   describe "String#dajarize" do


### PR DESCRIPTION
`GoogleSuggest` on which `pebbles-dajare` depends allows users to specify target endpoint of the API with `region` option. 

This PR enables to do it with `dajarize`. 
